### PR TITLE
Add google example

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ No modules.
 |------|------|
 | [aws_identitystore_group.sso_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_group) | resource |
 | [aws_identitystore_group_membership.sso_group_membership](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_group_membership) | resource |
+| [aws_identitystore_group_membership.sso_group_membership_existing_sso_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_group_membership) | resource |
 | [aws_identitystore_user.sso_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_user) | resource |
 | [aws_ssoadmin_account_assignment.account_assignment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment) | resource |
 | [aws_ssoadmin_customer_managed_policy_attachment.pset_customer_managed_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_customer_managed_policy_attachment) | resource |

--- a/examples/google-workspace/.header.md
+++ b/examples/google-workspace/.header.md
@@ -1,0 +1,40 @@
+This directory contains examples of using the module to reference existing users, and assign those users to groups created within this module. This is sometimes desirable because Google Workspace currently only syncs users, not groups via SCIM. This allows you to sync users from Google Workspace, but place them into groups that you create with this module.
+
+**IMPORTANT:** Ensure that the name of your object matches the name of your principal (e.g. user name or group name). See the following example with object/principal names 'Admin' and 'nuzumaki':
+
+```hcl
+  sso_groups = {
+    Admin : {
+      group_name        = "Admin"
+      group_description = "Admin IAM Identity Center Group"
+    },
+  }
+
+  // Create desired USERS in IAM Identity Center
+  sso_users = {
+    nuzumaki : {
+      group_membership = ["Admin",]
+      user_name        = "nuzumaki"
+      given_name       = "Naruto"
+      family_name      = "Uzumaki"
+      email            = "nuzumaki@hiddenleaf.village"
+    },
+  }
+
+```
+
+These names are referenced throughout the module. Failure to do this may lead to unintentional errors such as the following:
+
+```
+Error: Invalid index
+│
+│   on ../../main.tf line 141, in resource "aws_identitystore_group_membership" "sso_group_membership":
+│  141:   member_id = (contains(local.this_users, each.value.user_name) ? aws_identitystore_user.sso_users[each.value.user_name].user_id : data.aws_identitystore_user.existing_sso_users[each.value.user_name].id)
+│     ├────────────────
+│     │ aws_identitystore_user.sso_users is object with 2 attributes
+│     │ each.value.user_name is "nuzumaki"
+│
+│ The given key does not identify an element in this collection value.
+```
+
+To resolve this, ensure your object and principal names are the same and re-run `terraform plan` and `terraform apply`.

--- a/examples/google-workspace/README.md
+++ b/examples/google-workspace/README.md
@@ -1,0 +1,72 @@
+<!-- BEGIN_TF_DOCS -->
+This directory contains examples of using the module to reference existing users, and assign those users to groups created within this module. This is sometimes desirable because Google Workspace currently only syncs users, not groups via SCIM. This allows you to sync users from Google Workspace, but place them into groups that you create with this module.
+
+**IMPORTANT:** Ensure that the name of your object matches the name of your principal (e.g. user name or group name). See the following example with object/principal names 'Admin' and 'nuzumaki':
+
+```hcl
+  sso_groups = {
+    Admin : {
+      group_name        = "Admin"
+      group_description = "Admin IAM Identity Center Group"
+    },
+  }
+
+  // Create desired USERS in IAM Identity Center
+  sso_users = {
+    nuzumaki : {
+      group_membership = ["Admin",]
+      user_name        = "nuzumaki"
+      given_name       = "Naruto"
+      family_name      = "Uzumaki"
+      email            = "nuzumaki@hiddenleaf.village"
+    },
+  }
+
+```
+
+These names are referenced throughout the module. Failure to do this may lead to unintentional errors such as the following:
+
+```
+Error: Invalid index
+│
+│   on ../../main.tf line 141, in resource "aws_identitystore_group_membership" "sso_group_membership":
+│  141:   member_id = (contains(local.this_users, each.value.user_name) ? aws_identitystore_user.sso_users[each.value.user_name].user_id : data.aws_identitystore_user.existing_sso_users[each.value.user_name].id)
+│     ├────────────────
+│     │ aws_identitystore_user.sso_users is object with 2 attributes
+│     │ each.value.user_name is "nuzumaki"
+│
+│ The given key does not identify an element in this collection value.
+```
+
+To resolve this, ensure your object and principal names are the same and re-run `terraform plan` and `terraform apply`.
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws-iam-identity-center"></a> [aws-iam-identity-center](#module\_aws-iam-identity-center) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ssm_parameter.account1_account_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/examples/google-workspace/locals.tf
+++ b/examples/google-workspace/locals.tf
@@ -1,0 +1,14 @@
+# Fetch Account Id from SSM Parameter Store
+data "aws_ssm_parameter" "account1_account_id" {
+  name = "tf-aws-iam-idc-module-testing-account1-account-id" // replace with your SSM Parameter Key
+}
+
+locals {
+  # Account IDs
+  account1_account_id = nonsensitive(data.aws_ssm_parameter.account1_account_id.value)
+  # account1_account_id = "111111111111"
+  # account2_account_id = "222222222222"
+  # account3_account_id = "333333333333"
+  # account4_account_id = "444444444444"
+
+}

--- a/examples/google-workspace/main.tf
+++ b/examples/google-workspace/main.tf
@@ -1,0 +1,80 @@
+module "aws-iam-identity-center" {
+  source = "../.." // local example
+  # source = "aws-ia/iam-identity-center/aws" // remote example
+
+  # Create group
+  sso_groups = {
+    Admin : {
+      group_name = "Admin"
+    },
+    Audit : {
+      group_name = "Audit"
+    },
+  }
+  # Assign Google user to groups
+  existing_sso_users = {
+    googleuser : {
+      user_name        = "googleuser" # this must be the name of a user that already exists in your AWS account
+      group_membership = ["Admin", "Audit"]
+    },
+  }
+
+
+  # Create permissions sets backed by AWS managed policies
+  permission_sets = {
+    AdministratorAccess = {
+      description          = "Provides AWS full access permissions.",
+      session_duration     = "PT4H", // how long until session expires - this means 4 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+    ViewOnlyAccess = {
+      description          = "Provides AWS view only permissions.",
+      session_duration     = "PT3H", // how long until session expires - this means 3 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+  }
+
+
+  # Assign users/groups access to accounts with the specified permissions
+  account_assignments = {
+    Admin : {
+      principal_name  = "Admin"
+      principal_type  = "GROUP"
+      principal_idp   = "INTERNAL" # set to "INTERNAL" because group was created on AWS side, not synced from "EXTERNAL" IdP
+      permission_sets = ["AdministratorAccess", "ViewOnlyAccess", ]
+      account_ids = [              // account(s) the user will have access to. Permissions they will have in account are above line
+        local.account1_account_id, // locals are used to allow for global changes to multiple account assignments
+        # local.account2_account_id, // if hard coding the account ids, you would need to change them in every place you want to change
+        # local.account3_account_id, // these are defined in a locals.tf file, example is in this directory
+        # local.account4_account_id,
+      ]
+    },
+    Audit : {
+      principal_name  = "Audit"
+      principal_type  = "GROUP"
+      principal_idp   = "INTERNAL" # set to "INTERNAL" because group was created on AWS side, not synced from "EXTERNAL" IdP
+      permission_sets = ["ViewOnlyAccess", ]
+      account_ids = [              // account(s) the user will have access to. Permissions they will have in account are above line
+        local.account1_account_id, // locals are used to allow for global changes to multiple account assignments
+        # local.account2_account_id, // if hard coding the account ids, you would need to change them in every place you want to change
+        # local.account3_account_id, // these are defined in a locals.tf file, example is in this directory
+        # local.account4_account_id,
+      ]
+    },
+    googleuser : {
+      principal_name  = "googleuser"
+      principal_type  = "USER"
+      principal_idp   = "EXTERNAL" # set to "EXTERNAL" because user was created in "EXTERNAL" IdP and was synced to AWS via SCIM
+      permission_sets = ["ViewOnlyAccess"]
+      account_ids = [              // account(s) the user will have access to. Permissions they will have in account are above line
+        local.account1_account_id, // locals are used to allow for global changes to multiple account assignments
+        # local.account2_account_id, // if hard coding the account ids, you would need to change them in every place you want to change
+        # local.account3_account_id, // these are defined in a locals.tf file, example is in this directory
+        # local.account4_account_id,
+      ]
+    },
+  }
+
+}

--- a/locals.tf
+++ b/locals.tf
@@ -14,7 +14,23 @@ locals {
     for s in local.flatten_user_data : format("%s_%s", s.user_name, s.group_name) => s
   }
 
+  # Create a new local variable by flattening the complex type given in the variable "sso_users"
+  flatten_user_data_existing_sso_users = flatten([
+    for this_user in keys(var.existing_sso_users) : [
+      for group in var.existing_sso_users[this_user].group_membership : {
+        user_name  = var.existing_sso_users[this_user].user_name
+        group_name = group
+      }
+    ]
+  ])
+
+  users_and_their_groups_existing_sso_users = {
+    for s in local.flatten_user_data_existing_sso_users : format("%s_%s", s.user_name, s.group_name) => s
+  }
+
 }
+
+
 
 
 # - Permission Sets and Policies -

--- a/main.tf
+++ b/main.tf
@@ -140,6 +140,15 @@ resource "aws_identitystore_group_membership" "sso_group_membership" {
 
 }
 
+resource "aws_identitystore_group_membership" "sso_group_membership_existing_sso_users" {
+  for_each          = local.users_and_their_groups_existing_sso_users
+  identity_store_id = local.sso_instance_id
+
+  group_id  = (contains(local.this_groups, each.value.group_name) ? aws_identitystore_group.sso_groups[each.value.group_name].group_id : data.aws_identitystore_group.existing_sso_groups[each.value.group_name].group_id)
+  member_id = (contains(local.this_users, each.value.user_name) ? aws_identitystore_user.sso_users[each.value.user_name].user_id : data.aws_identitystore_user.existing_sso_users[each.value.user_name].user_id)
+
+}
+
 
 # - SSO Permission Set -
 resource "aws_ssoadmin_permission_set" "pset" {

--- a/test/google_workspace_test.go
+++ b/test/google_workspace_test.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestGoogleWorkspace(t *testing.T) {
+
+	terraformOptions := &terraform.Options{
+		// The path to where your Terraform code is located
+		TerraformDir: "../examples/google-workspace",
+
+	}
+
+	// At the end of the test, run 'terraform destroy' to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Run 'terraform init' and 'terraform apply'. Fail the test if there are any errors.
+	terraform.InitAndApply(t, terraformOptions)
+
+}


### PR DESCRIPTION
This PR does the following:
- Adds support for users synced (via SCIM) to be added to groups created via this module. This is support the limitation in Google Workspace where SCIM does not sync Groups
- Adds example for Google Workspace